### PR TITLE
Add ListenAndServeTLS

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,10 +2,9 @@ package synapse
 
 import (
 	//"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/philhofer/fwd"
-	"github.com/tinylib/msgp/msgp"
 	"io"
 	"log"
 	"net"
@@ -13,6 +12,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/philhofer/fwd"
+	"github.com/tinylib/msgp/msgp"
 )
 
 const (
@@ -53,6 +55,16 @@ type AsyncResponse interface {
 // for requests, in milliseconds.
 func Dial(network string, laddr string, timeout int64) (*Client, error) {
 	conn, err := net.Dial(network, laddr)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(conn, timeout)
+}
+
+// DialTLS acts identically to Dial, except that it dials the connection
+// over TLS using the provided *tls.Config.
+func DialTLS(network, laddr string, timeout int64, config *tls.Config) (*Client, error) {
+	conn, err := tls.Dial(network, laddr, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Calling tls.Listen() and passing that connection to Serve() does work (as expected). I just thought this provided a simpler interface for users. However, we should also offer a client for this (obviously), so I'm just cleaning that up now and will push soon (to this branch).

This is in reference to issue #13 .

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/synapse/14)
<!-- Reviewable:end -->
