### PR TITLE
fine-grained locking ftw

### DIFF
--- a/_examples/arith/client/main.go
+++ b/_examples/arith/client/main.go
@@ -23,22 +23,9 @@ func main() {
 	pi := 3.14159
 	num := Num{Value: pi}
 
-	// here we make an asynchronous
-	// call to the service
 	fmt.Println("Asking the remote server to double 3.14159 for us...")
-	res, err := cl.Async("double", &num)
+	err = cl.Call("double", &num, synapse.JSPipe(os.Stdout))
 	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	// the call to Read blocks
-	// until we get a response.
-	// JSPipe sends whatever data
-	// is returned to an io.Writer as
-	// JSON.
-	err = res.Read(synapse.JSPipe(os.Stdout))
-	if err != nil {
-		fmt.Println(err)
+		fmt.Println("ERROR:", err)
 	}
 }

--- a/_examples/arith/server/main.go
+++ b/_examples/arith/server/main.go
@@ -30,6 +30,6 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-
+	fmt.Println("listening on :7070...")
 	fmt.Println(synapse.Serve(l, mux))
 }

--- a/handler.go
+++ b/handler.go
@@ -25,10 +25,12 @@ type Status int
 // an error to send to the
 // client.
 const (
-	// The zero value for
-	// Status is InvalidStatus
+	// InvalidStatus is the
+	// zero value of Status.
 	InvalidStatus Status = iota
 
+	// un-exported, because 'ok'
+	// is not really an error
 	okStatus
 
 	// NotFound means the

--- a/map.go
+++ b/map.go
@@ -1,0 +1,171 @@
+package synapse
+
+import (
+	"sync"
+)
+
+const (
+	// number of significant bits in
+	// bucket addressing. more bits
+	// means more memory and better
+	// worst-case performance.
+	bucketBits = 6
+
+	// number of buckets per map
+	mbuckets = 1 << bucketBits
+
+	// bitmask for bucket index
+	bucketMask = mbuckets - 1
+)
+
+// wMap is really buckets of queues.
+// locking is done on the bucket level, so
+// concurrent reads and writes generally do
+// not contend with one another. the fact that
+// waiters are inserted and deleted in approximately
+// FIFO order means that we can often expect best-case
+// performance for removal.
+type wMap [mbuckets]mNode
+
+// returns a sequence number's canonical node
+func (w *wMap) node(seq uint64) *mNode { return &w[seq&bucketMask] }
+
+// a node is just a linked list of *waiter with
+// a mutex protecting access
+type mNode struct {
+	sync.Mutex
+	list *waiter // stack of *waiter
+	tail *waiter // insert point
+}
+
+// pop searches the list from top to bottom
+// for the sequence number 'seq' and removes
+// the *waiter from the list if it exists. returns
+// nil otherwise.
+func (n *mNode) pop(seq uint64) *waiter {
+	fwd := &n.list
+	var prev *waiter
+	for cur := n.list; cur != nil; cur = cur.next {
+		if cur.seq == seq {
+			if cur == n.tail {
+				n.tail = prev
+			}
+			*fwd, cur.next = cur.next, nil
+			return cur
+		}
+		fwd = &cur.next
+		prev = cur
+	}
+	return nil
+}
+
+// insert puts a waiter at the tail of the list
+func (n *mNode) insert(q *waiter) {
+	if n.list == nil {
+		n.list = q
+	} else {
+		n.tail.next = q
+	}
+	n.tail = q
+}
+
+func (n *mNode) size() (i int) {
+	for w := n.list; w != nil; w = w.next {
+		i++
+	}
+	return
+}
+
+// flush waiters marked with 'reap',
+// and mark unmarked waiters.
+func (n *mNode) reap() {
+	fwd := &n.list
+	var prev *waiter
+	for cur := n.list; cur != nil; {
+		if cur.reap {
+			if cur == n.tail {
+				n.tail = prev
+			}
+			*fwd, cur.next = cur.next, nil
+			cur.err = ErrTimeout
+			cur.done.Unlock()
+			cur = *fwd
+		} else {
+			cur.reap = true
+			prev = cur
+			fwd = &cur.next
+			cur = cur.next
+		}
+	}
+}
+
+// flush the entire contents of the node
+func (n *mNode) flush(err error) {
+	var next *waiter
+	for l := n.list; l != nil; {
+		next, l.next = l.next, nil
+		l.err = err
+		l.done.Unlock()
+		l = next
+	}
+	n.list = nil
+	n.tail = nil
+}
+
+// insert inserts a waiter keyed on its
+// sequence number. this has undefined behavior
+// if the waiter is already in the map. (!!!)
+func (w *wMap) insert(q *waiter) {
+	n := w.node(q.seq)
+	n.Lock()
+	n.insert(q)
+	n.Unlock()
+}
+
+// remove gets a value and removes it if it exists.
+// it returns nil if it didn't exist in the first place.
+func (w *wMap) remove(seq uint64) *waiter {
+	n := w.node(seq)
+	n.Lock()
+	wt := n.pop(seq)
+	n.Unlock()
+	return wt
+}
+
+// return the total size of the map... sort of.
+// this is only used for testing. during concurrent
+// access, the returned value may not be the size
+// of the map at *any* fixed point in time. it's
+// an approximation.
+func (w *wMap) length() (count int) {
+	for i := range w {
+		n := &w[i]
+		n.Lock()
+		count += n.size()
+		n.Unlock()
+	}
+	return count
+}
+
+// unlock every waiter with the provided error,
+// and then zero out the entire contents of the map
+func (w *wMap) flush(err error) {
+	for i := range w {
+		n := &w[i]
+		n.Lock()
+		n.flush(err)
+		n.Unlock()
+	}
+}
+
+// reap carries out a timeout reap.
+// if (*waiter).reap==true, then delete it,
+// otherwise set (*waiter).reap to true.
+func (w *wMap) reap() {
+	for i := range w {
+		n := &w[i]
+		n.Lock()
+		n.reap()
+		n.Unlock()
+	}
+}

--- a/map_test.go
+++ b/map_test.go
@@ -1,0 +1,185 @@
+package synapse
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestWaiterMap(t *testing.T) {
+	mp := &wMap{}
+
+	q := mp.remove(4309821)
+	if q != nil {
+		t.Error("remove() should return 'nil' from an empty map")
+	}
+
+	vals := make([]waiter, 1000)
+	for i := range vals {
+		vals[i].seq = uint64(i) * 17
+	}
+
+	for i := range vals {
+		mp.insert(&vals[i])
+	}
+
+	if mp.length() != 1000 {
+		t.Errorf("expected map to have 1000 elements; found %d", mp.length())
+	}
+
+	for i := range vals {
+		q := mp.remove(vals[i].seq)
+		if q != &vals[i] {
+			t.Errorf("expected %v; got %v", &vals[i], q)
+		}
+	}
+
+	l := mp.length()
+	if l != 0 {
+		t.Errorf("expected map to have 0 elements; found %d", l)
+	}
+
+	vals[200].done.Lock()
+	mp.insert(&vals[200])
+
+	mp.flush(nil)
+
+	if mp.length() != 0 {
+		t.Errorf("expected map length to be 0 after flush(); found %d", mp.length())
+	}
+
+	for i := range vals {
+		vals[i].done.Lock()
+		mp.insert(&vals[i])
+	}
+
+	l = mp.length()
+	if l != 1000 {
+		t.Errorf("expected 1000 elements after re-insertion; found %d", l)
+	}
+
+	mp.reap()
+
+	l = mp.length()
+	if l != 1000 {
+		t.Errorf("expected 1000 elements after first reap(); found %d", l)
+	}
+
+	mp.reap()
+
+	l = mp.length()
+	if l != 0 {
+		t.Errorf("expected 0 elements after second reap(); found %d", l)
+	}
+
+	for i := range vals {
+		vals[i].done.Lock()
+		vals[i].reap = false
+		mp.insert(&vals[i])
+	}
+
+	// non-sequential removal
+	for i := range vals {
+		x := &vals[len(vals)-i-1]
+		v := mp.remove(x.seq)
+		if v == nil {
+			t.Errorf("index %d: no value returned", len(vals)-i-1)
+		}
+		if v != x {
+			t.Errorf("expected %v out; got %v", x, v)
+		}
+	}
+}
+
+func seqInsert(mp *wMap, b *testing.B, num int) {
+	vals := make([]waiter, num)
+	for i := range vals {
+		vals[i].seq = uint64(i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range vals {
+			mp.insert(&vals[j])
+		}
+		for j := range vals {
+			mp.remove(uint64(j))
+		}
+	}
+}
+
+func stdInsert(mp map[uint64]*waiter, b *testing.B, num int) {
+	vals := make([]waiter, num)
+	for i := range vals {
+		vals[i].seq = uint64(i)
+	}
+	// the mutex is just for symmetry
+	// with the other map implementation,
+	// as it does one lock per insert/delete
+	var m sync.Mutex
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := range vals {
+			m.Lock()
+			mp[vals[j].seq] = &vals[j]
+			m.Unlock()
+		}
+		for j := range vals {
+			m.Lock()
+			if mp[vals[j].seq] != nil {
+				delete(mp, vals[j].seq)
+			}
+			m.Unlock()
+		}
+	}
+}
+
+func BenchmarkMapInsertDelete(b *testing.B) {
+	var mp wMap
+	w := &waiter{}
+	w.seq = 39082134
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mp.insert(w)
+		mp.remove(w.seq)
+	}
+}
+
+func BenchmarkStdMapInsertDelete(b *testing.B) {
+	mp := make(map[uint64]*waiter)
+	w := &waiter{}
+	w.seq = 39082134
+	b.ReportAllocs()
+	b.ResetTimer()
+	var m sync.Mutex
+	for i := 0; i < b.N; i++ {
+		m.Lock()
+		mp[w.seq] = w
+		m.Unlock()
+		m.Lock()
+		w = mp[w.seq]
+		delete(mp, w.seq)
+		m.Unlock()
+	}
+}
+
+func Benchmark1000Sequential(b *testing.B) {
+	var mp wMap
+	seqInsert(&mp, b, 1000)
+}
+
+func Benchmark500Sequential(b *testing.B) {
+	var mp wMap
+	seqInsert(&mp, b, 500)
+}
+
+func Benchmark1000StdSequential(b *testing.B) {
+	mp := make(map[uint64]*waiter)
+	stdInsert(mp, b, 1000)
+}
+
+func Benchmark500StdSequential(b *testing.B) {
+	mp := make(map[uint64]*waiter)
+	stdInsert(mp, b, 500)
+}

--- a/stack.go
+++ b/stack.go
@@ -16,11 +16,9 @@ import (
 // then create a LIFO out of them during
 // initialization. if we run out of elements
 // in the stack, we fall back to using the
-// heap, and we set the 'next' pointer
-// in the returned element to itself.
-// push() operations check for 'next==self'
-// and no-op in that case, since we don't
-// want the stack to grow forever without bound.
+// heap. wrappers are heap-allocated if
+// c.next == c, and waiters are heap allocated
+// if (*waiter).static == false.
 
 const arenaSize = 512
 
@@ -36,9 +34,11 @@ func init() {
 	// set up the pointers and lock
 	// the waiter semaphores
 	waiterSlab[0].done.Lock()
+	waiterSlab[0].static = true
 	for i := 0; i < (arenaSize - 1); i++ {
 		waiterSlab[i].next = &waiterSlab[i+1]
 		waiterSlab[i+1].done.Lock()
+		waiterSlab[i+1].static = true
 		wrapperSlab[i].next = &wrapperSlab[i+1]
 	}
 	waiters.top = &waiterSlab[0]
@@ -78,18 +78,22 @@ func (s *connStack) push(ptr *connWrapper) {
 	return
 }
 
+// the following should always hold:
+//  - ptr.next = nil
+//  - ptr.parent = c
+//  - ptr.done is Lock()ed
 func (s *waitStack) pop(c *Client) (ptr *waiter) {
 	spin.Lock(&s.lock)
 	if s.top != nil {
 		ptr, s.top = s.top, s.top.next
 		spin.Unlock(&s.lock)
 		ptr.parent = c
-		return ptr
+		ptr.next = nil
+		return
 	}
 	spin.Unlock(&s.lock)
 	ptr = &waiter{}
 	ptr.parent = c
-	ptr.next = ptr
 	ptr.done.Lock()
 	return
 }
@@ -97,7 +101,7 @@ func (s *waitStack) pop(c *Client) (ptr *waiter) {
 func (s *waitStack) push(ptr *waiter) {
 	ptr.parent = nil
 	ptr.err = nil
-	if ptr.next == ptr {
+	if !ptr.static {
 		return
 	}
 	spin.Lock(&s.lock)

--- a/stack_race.go
+++ b/stack_race.go
@@ -15,12 +15,12 @@ var (
 type waitStack struct{}
 type connStack struct{}
 
-func (_ waitStack) push(_ *waiter) {}
-func (_ waitStack) pop(c *Client) *waiter {
+func (ws waitStack) push(_ *waiter) {}
+func (ws waitStack) pop(c *Client) *waiter {
 	w := &waiter{parent: c}
 	w.done.Lock()
 	return w
 }
 
-func (_ connStack) pop() *connWrapper   { return &connWrapper{} }
-func (_ connStack) push(_ *connWrapper) {}
+func (cs connStack) pop() *connWrapper   { return &connWrapper{} }
+func (cs connStack) push(_ *connWrapper) {}


### PR DESCRIPTION
Before, pending requests live in a `map[uint64]*waiter`. While that was expedient, it was not fast.

The implementation of sequence numbers on the client side gives us the opportunity to take advantage of the fact that sequence numbers are monotonic and thus uniformly distributed.

What I have here is a static array of thread-safe queues. The way it works is it takes the last `rootBits` bits (6, in this case) of the sequence number as an offset into the "root array." From there, it's just naive search through a queue (while holding the queue's lock). This has a couple notable properties:

 - Locking is per-list, so a 64-node map can have 64 concurrent mutators.
 - Waiters are already allocated, so the data structure itself does zero allocation *ever*. However, the structure itself is quite large.
 - O(1) insertion all the time.
 - O(n) average-case removal *technically*, but best-case (O(1)) is extremely common, because we insert at the tail and search for removal beginning at the head. (Insertion/removal pattern is approximately FIFO.)
 - The timeout "reap" process doesn't have to lock the entire map at once, so it's much friendlier to calls actually making forward progress. More broadly, most things that have to iterate over the map don't need to observe it in a perfectly consistent state, and so they don't cause as much contention.

So now for the good stuff:

`GOMAXPROCS=4`

| Benchmark | Before | After | Delta |
|:---------------:|:---------:|:------:|:-------:|
| TCP Echo | 3005 ns | 1677 ns | -44% |
| Unix no-op | 1370 ns | 1190 ns | -13% |
| Pipe no-op | 1228 ns | 899 ns | -27% |

`GOMAXPROCS=1`

| Benchmark | Before | After | Delta |
|:---------------:|:---------:|:------:|:-------:|
| TCP Echo | 3866 ns | 3788 ns | -2% |
| Unix no-op | 2231 ns | 2071 ns | -7% |
| Pipe no-op | 1646 ns | 1569 ns | -5% |

So it *is* faster in the un-contended case as well.

Warning: This is still very much a work in progress. Gross code ahead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/synapse/20)
<!-- Reviewable:end -->