### PR TITLE
res.Error() takes code and string

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,7 +71,6 @@ func DialTLS(network, raddr string, timeout time.Duration, config *tls.Config) (
 func NewClient(c net.Conn, timeout time.Duration) (*Client, error) {
 	cl := &Client{
 		conn:    c,
-		bwr:     fwd.NewWriter(c),
 		writing: make(chan *waiter, waiterHWM),
 		done:    make(chan struct{}),
 		state:   clientOpen,
@@ -95,7 +94,6 @@ func NewClient(c net.Conn, timeout time.Duration) (*Client, error) {
 // a single synapse server.
 type Client struct {
 	conn    net.Conn       // connection
-	bwr     *fwd.Writer    // wraps conn
 	wlock   sync.Mutex     // write lock
 	csn     uint64         // sequence number; atomic
 	writing chan *waiter   // queue to write to conn; size is effectively HWM
@@ -365,7 +363,7 @@ func (w *waiter) read(out msgp.Unmarshaler) error {
 	if err != nil {
 		return err
 	}
-	if Status(code) != okStatus {
+	if Status(code) != StatusOK {
 		str, _, err := msgp.ReadStringBytes(w.in)
 		if err != nil {
 			str = "<?>"

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,13 @@ import (
 	"time"
 )
 
+func isCode(err error, c Status) bool {
+	if reserr, ok := err.(*ResponseError); ok && reserr.Code == c {
+		return true
+	}
+	return false
+}
+
 // open up a client and server; make
 // some concurrent requests
 func TestClient(t *testing.T) {
@@ -35,8 +42,8 @@ func TestClient(t *testing.T) {
 
 	// test for NotFound
 	err := tcpClient.Call("doesn't-exist", nil, nil)
-	if err != NotFound {
-		t.Errorf("expected error %v; got %v", NotFound, err)
+	if !isCode(err, StatusNotFound) {
+		t.Errorf("expected not-found error; got %#v", err)
 	}
 }
 
@@ -79,7 +86,7 @@ func BenchmarkTCPEcho(b *testing.B) {
 	mux.Handle("echo", EchoHandler{})
 
 	go Serve(l, mux)
-	cl, err := Dial("tcp", "localhost:7000", 1*time.Millisecond)
+	cl, err := Dial("tcp", "localhost:7000", 50*time.Millisecond)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/debug.go
+++ b/debug.go
@@ -59,7 +59,7 @@ func (d *debugh) ServeCall(req Request, res ResponseWriter) {
 	err := req.Decode(&raw)
 	if err != nil {
 		d.logger.Printf("request from %s for %q is malformed: %s\n", remote, nm, err)
-		res.Error(BadRequest)
+		res.Error(StatusBadRequest, err.Error())
 		return
 	}
 	msgp.UnmarshalAsJSON(&buf, []byte(raw))
@@ -74,7 +74,7 @@ func (d *debugh) ServeCall(req Request, res ResponseWriter) {
 	d.inner.ServeCall(r, w)
 	if !w.wrote {
 		d.logger.Print("WARNING: handler for", nm, "did not write a valid response")
-		res.Error(ServerError)
+		res.Error(StatusServerError, "empty response")
 		return
 	}
 	msgp.UnmarshalAsJSON(&buf, []byte(w.out))
@@ -116,12 +116,13 @@ func (m *mockRes) Send(g msgp.Marshaler) error {
 	return nil
 }
 
-func (m *mockRes) Error(s Status) {
+func (m *mockRes) Error(s Status, r string) {
 	if m.wrote {
 		return
 	}
 	m.wrote = true
 	m.status = s
+	m.out = msgp.AppendString(m.out, r)
 }
 
 func (d *debugh) serveBase(req *request, res *response) {
@@ -130,7 +131,7 @@ func (d *debugh) serveBase(req *request, res *response) {
 	remote := req.addr.String()
 	if err != nil {
 		d.logger.Printf("request from %s for %q was malformed: %s", remote, req.name, err)
-		res.Error(BadRequest)
+		res.Error(StatusBadRequest, err.Error())
 		return
 	}
 	d.logger.Printf("request from %s:\n\tNAME: %q\n\tBODY: %s\n", remote, req.name, buf.String())
@@ -138,7 +139,7 @@ func (d *debugh) serveBase(req *request, res *response) {
 	d.inner.ServeCall(req, res)
 	if !res.wrote || len(res.out) < leadSize {
 		d.logger.Print("WARNING: handler for", req.name, "did not write a valid response")
-		res.Error(ServerError)
+		res.Error(StatusServerError, "empty response")
 		return
 	}
 	out := res.out[leadSize:]
@@ -155,5 +156,5 @@ func (d *debugh) serveBase(req *request, res *response) {
 		d.logger.Printf("response for %s is malformed: %s", req.name, err)
 		return
 	}
-	d.logger.Printf("response to %s for %q:\n\tSTATUS: %s\n\tBODY: %s\n", remote, req.name, status.Error(), buf.String())
+	d.logger.Printf("response to %s for %q:\n\tSTATUS: %s\n\tBODY: %s\n", remote, req.name, status, buf.String())
 }

--- a/debug.go
+++ b/debug.go
@@ -112,7 +112,7 @@ func (m *mockRes) Send(g msgp.Marshaler) error {
 	if err != nil {
 		return err
 	}
-	m.status = okStatus
+	m.status = StatusOK
 	return nil
 }
 

--- a/handler.go
+++ b/handler.go
@@ -30,7 +30,7 @@ type Status int
 // client.
 const (
 	StatusInvalid     Status = iota // zero-value for Status
-	okStatus                        // not an error; not exported
+	StatusOK                        // OK
 	StatusNotFound                  // no handler for the request method
 	StatusCondition                 // precondition failure
 	StatusBadRequest                // mal-formed request
@@ -56,8 +56,8 @@ func (e *ResponseError) Error() string {
 // String returns the string representation of the status
 func (s Status) String() string {
 	switch s {
-	case okStatus:
-		return "<ok>"
+	case StatusOK:
+		return "OK"
 	case StatusNotFound:
 		return "not found"
 	case StatusCondition:

--- a/handler.go
+++ b/handler.go
@@ -1,5 +1,9 @@
 package synapse
 
+import (
+	"fmt"
+)
+
 // Handler is the interface used
 // to register server response callbacks.
 type Handler interface {
@@ -25,50 +29,48 @@ type Status int
 // an error to send to the
 // client.
 const (
-	// InvalidStatus is the
-	// zero value of Status.
-	InvalidStatus Status = iota
-
-	// un-exported, because 'ok'
-	// is not really an error
-	okStatus
-
-	// NotFound means the
-	// call requested could
-	// not be located on the
-	// server
-	NotFound
-
-	// BadRequest means the
-	// request was not formatted
-	// as expected
-	BadRequest
-
-	// NotAuthed means the client
-	// was not authorized to make
-	// the call
-	NotAuthed
-
-	// ServerError means the server
-	// encountered an error when
-	// making the call
-	ServerError
+	StatusInvalid     Status = iota // zero-value for Status
+	okStatus                        // not an error; not exported
+	StatusNotFound                  // no handler for the request method
+	StatusCondition                 // precondition failure
+	StatusBadRequest                // mal-formed request
+	StatusNotAuthed                 // not authorized
+	StatusServerError               // server-side error
+	StatusOther                     // other error
 )
 
-// Status implements the error interface
-func (s Status) Error() string {
+// ResponseError is the type of error
+// returned by the client when the
+// server sends a response with
+// ResponseWriter.Error()
+type ResponseError struct {
+	Code Status
+	Expl string
+}
+
+// Error implements error
+func (e *ResponseError) Error() string {
+	return fmt.Sprintf("synapse: response error (%s): %s", e.Code, e.Expl)
+}
+
+// String returns the string representation of the status
+func (s Status) String() string {
 	switch s {
 	case okStatus:
 		return "<ok>"
-	case NotFound:
+	case StatusNotFound:
 		return "not found"
-	case BadRequest:
+	case StatusCondition:
+		return "precondition failed"
+	case StatusBadRequest:
 		return "bad request"
-	case NotAuthed:
+	case StatusNotAuthed:
 		return "not authorized"
-	case ServerError:
+	case StatusServerError:
 		return "server error"
+	case StatusOther:
+		return "other"
 	default:
-		return "<invalid status>"
+		return fmt.Sprintf("Status(%d)", s)
 	}
 }

--- a/mux.go
+++ b/mux.go
@@ -32,7 +32,7 @@ func (f handlerFunc) ServeCall(req Request, res ResponseWriter) { f(req, res) }
 func (r *Router) ServeCall(req Request, res ResponseWriter) {
 	h, ok := r.hlrs[req.Name()]
 	if !ok {
-		res.Error(NotFound)
+		res.Error(StatusNotFound, "no handler by that name")
 		return
 	}
 	h.ServeCall(req, res)

--- a/response.go
+++ b/response.go
@@ -61,7 +61,7 @@ func (r *response) Send(msg msgp.Marshaler) error {
 
 	var err error
 	r.resetLead()
-	r.out = msgp.AppendInt(r.out, int(okStatus))
+	r.out = msgp.AppendInt(r.out, int(StatusOK))
 	if msg != nil {
 		r.out, err = msg.MarshalMsg(r.out)
 		if err != nil {

--- a/response.go
+++ b/response.go
@@ -14,9 +14,10 @@ const outPrealloc = 256
 // to either method should no-op.
 type ResponseWriter interface {
 	// Error sets an error status
-	// to be returned to the caller
-	// instead of a full body.
-	Error(Status)
+	// to be returned to the caller,
+	// along with an explanation
+	// of the error.
+	Error(Status, string)
 
 	// Send sets the body to be
 	// returned to the caller.
@@ -41,13 +42,14 @@ func (r *response) resetLead() {
 }
 
 // base Error implementation
-func (r *response) Error(s Status) {
+func (r *response) Error(s Status, expl string) {
 	if r.wrote {
 		return
 	}
 	r.wrote = true
 	r.resetLead()
 	r.out = msgp.AppendInt(r.out, int(s))
+	r.out = msgp.AppendString(r.out, expl)
 }
 
 // base Send implementation

--- a/server.go
+++ b/server.go
@@ -293,7 +293,7 @@ func (c *connHandler) handleReq(cw *connWrapper) {
 	// split request into 'name' and body
 	cw.req.name, cw.req.in, err = msgp.ReadStringBytes(cw.in)
 	if err != nil {
-		cw.res.Error(BadRequest)
+		cw.res.Error(StatusBadRequest, "malformed request method")
 	} else {
 		c.h.ServeCall(&cw.req, &cw.res)
 		// if the handler didn't write a body,


### PR DESCRIPTION
Change is as follows:

```go
type ResponseWriter interface {
    Error(Status, string) // instead of Error(Status)
// ...
}
```

Servers can (and should) send explanations along with error codes.

When clients receive an error response from a server, they return a `*ResponseError` which contains the code and the explanation string. @ttacon 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/synapse/23)
<!-- Reviewable:end -->
