### PR TITLE
Simplify routing - use a table

### DIFF
--- a/_examples/arith/client/main.go
+++ b/_examples/arith/client/main.go
@@ -13,6 +13,8 @@ type Num struct {
 	Value float64 `msg:"val"`
 }
 
+const Double synapse.Method = 0
+
 func main() {
 	cl, err := synapse.Dial("tcp", "localhost:7000", time.Second)
 	if err != nil {
@@ -25,7 +27,7 @@ func main() {
 	num := Num{Value: pi}
 
 	fmt.Println("Asking the remote server to double 3.14159 for us...")
-	err = cl.Call("double", &num, synapse.JSPipe(os.Stdout))
+	err = cl.Call(Double, &num, synapse.JSPipe(os.Stdout))
 	if err != nil {
 		fmt.Println("ERROR:", err)
 	}

--- a/_examples/arith/client/main_gen.go
+++ b/_examples/arith/client/main_gen.go
@@ -8,45 +8,37 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-// MarshalMsg implements the msgp.Marshaler interface
-func (z *Num) MarshalMsg(b []byte) (o []byte, err error) {
+// MarshalMsg implements msgp.Marshaler
+func (z Num) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-
-	o = msgp.AppendMapHeader(o, 1)
-
-	o = msgp.AppendString(o, "val")
-
+	// map header, size 1
+	// string "val"
+	o = append(o, 0x81, 0xa3, 0x76, 0x61, 0x6c)
 	o = msgp.AppendFloat64(o, z.Value)
-
 	return
 }
 
-// UnmarshalMsg unmarshals a Num from MessagePack, returning any extra bytes
-// and any errors encountered
+// UnmarshalMsg implements msgp.Unmarshaler
 func (z *Num) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-
 	var isz uint32
 	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for xplz := uint32(0); xplz < isz; xplz++ {
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-
 		case "val":
-
 			z.Value, bts, err = msgp.ReadFloat64Bytes(bts)
-
 			if err != nil {
 				return
 			}
-
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -54,18 +46,11 @@ func (z *Num) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		}
 	}
-
 	o = bts
 	return
 }
 
-// Msgsize implements the msgp.Sizer interface
-func (z *Num) Msgsize() (s int) {
-
-	s += msgp.MapHeaderSize
-	s += msgp.StringPrefixSize + 3
-
-	s += msgp.Float64Size
-
+func (z Num) Msgsize() (s int) {
+	s = 1 + 4 + msgp.Float64Size
 	return
 }

--- a/_examples/arith/client/main_gen_test.go
+++ b/_examples/arith/client/main_gen_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-func TestNumMarshalUnmarshal(t *testing.T) {
-	v := new(Num)
+func TestMarshalUnmarshalNum(t *testing.T) {
+	v := Num{}
 	bts, err := v.MarshalMsg(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestNumMarshalUnmarshal(t *testing.T) {
 	}
 }
 
-func BenchmarkNumMarshalMsg(b *testing.B) {
-	v := new(Num)
+func BenchmarkMarshalMsgNum(b *testing.B) {
+	v := Num{}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -42,8 +42,8 @@ func BenchmarkNumMarshalMsg(b *testing.B) {
 	}
 }
 
-func BenchmarkNumAppendMsg(b *testing.B) {
-	v := new(Num)
+func BenchmarkAppendMsgNum(b *testing.B) {
+	v := Num{}
 	bts := make([]byte, 0, v.Msgsize())
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
@@ -54,8 +54,8 @@ func BenchmarkNumAppendMsg(b *testing.B) {
 	}
 }
 
-func BenchmarkNumUnmarshal(b *testing.B) {
-	v := new(Num)
+func BenchmarkUnmarshalNum(b *testing.B) {
+	v := Num{}
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))

--- a/_examples/arith/server/main.go
+++ b/_examples/arith/server/main.go
@@ -12,24 +12,28 @@ type Num struct {
 	Value float64 `msg:"val"`
 }
 
-func main() {
-	mux := synapse.NewRouter()
-	mux.HandleFunc("double", func(req synapse.Request, res synapse.ResponseWriter) {
-		var n Num
-		err := req.Decode(&n)
-		if err != nil {
-			res.Error(synapse.BadRequest)
-			return
-		}
-		n.Value *= 2
-		res.Send(&n)
-	})
+const Double synapse.Method = 0
 
+type doubleHandler struct{}
+
+func (d doubleHandler) ServeCall(req synapse.Request, res synapse.ResponseWriter) {
+	var n Num
+	err := req.Decode(&n)
+	if err != nil {
+		res.Error(synapse.StatusBadRequest, err.Error())
+		return
+	}
+	n.Value *= 2
+	res.Send(&n)
+}
+
+func main() {
+	rt := synapse.RouteTable{Double: doubleHandler{}}
 	l, err := net.Listen("tcp", "localhost:7000")
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	fmt.Println("listening on :7070...")
-	fmt.Println(synapse.Serve(l, mux))
+	fmt.Println(synapse.Serve(l, &rt))
 }

--- a/_examples/arith/server/main_gen.go
+++ b/_examples/arith/server/main_gen.go
@@ -8,45 +8,37 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-// MarshalMsg implements the msgp.Marshaler interface
-func (z *Num) MarshalMsg(b []byte) (o []byte, err error) {
+// MarshalMsg implements msgp.Marshaler
+func (z Num) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-
-	o = msgp.AppendMapHeader(o, 1)
-
-	o = msgp.AppendString(o, "val")
-
+	// map header, size 1
+	// string "val"
+	o = append(o, 0x81, 0xa3, 0x76, 0x61, 0x6c)
 	o = msgp.AppendFloat64(o, z.Value)
-
 	return
 }
 
-// UnmarshalMsg unmarshals a Num from MessagePack, returning any extra bytes
-// and any errors encountered
+// UnmarshalMsg implements msgp.Unmarshaler
 func (z *Num) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-
 	var isz uint32
 	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for xplz := uint32(0); xplz < isz; xplz++ {
+	for isz > 0 {
+		isz--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
-
 		case "val":
-
 			z.Value, bts, err = msgp.ReadFloat64Bytes(bts)
-
 			if err != nil {
 				return
 			}
-
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -54,18 +46,11 @@ func (z *Num) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 		}
 	}
-
 	o = bts
 	return
 }
 
-// Msgsize implements the msgp.Sizer interface
-func (z *Num) Msgsize() (s int) {
-
-	s += msgp.MapHeaderSize
-	s += msgp.StringPrefixSize + 3
-
-	s += msgp.Float64Size
-
+func (z Num) Msgsize() (s int) {
+	s = 1 + 4 + msgp.Float64Size
 	return
 }

--- a/_examples/arith/server/main_gen_test.go
+++ b/_examples/arith/server/main_gen_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-func TestNumMarshalUnmarshal(t *testing.T) {
-	v := new(Num)
+func TestMarshalUnmarshalNum(t *testing.T) {
+	v := Num{}
 	bts, err := v.MarshalMsg(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -33,8 +33,8 @@ func TestNumMarshalUnmarshal(t *testing.T) {
 	}
 }
 
-func BenchmarkNumMarshalMsg(b *testing.B) {
-	v := new(Num)
+func BenchmarkMarshalMsgNum(b *testing.B) {
+	v := Num{}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -42,8 +42,8 @@ func BenchmarkNumMarshalMsg(b *testing.B) {
 	}
 }
 
-func BenchmarkNumAppendMsg(b *testing.B) {
-	v := new(Num)
+func BenchmarkAppendMsgNum(b *testing.B) {
+	v := Num{}
 	bts := make([]byte, 0, v.Msgsize())
 	bts, _ = v.MarshalMsg(bts[0:0])
 	b.SetBytes(int64(len(bts)))
@@ -54,8 +54,8 @@ func BenchmarkNumAppendMsg(b *testing.B) {
 	}
 }
 
-func BenchmarkNumUnmarshal(b *testing.B) {
-	v := new(Num)
+func BenchmarkUnmarshalNum(b *testing.B) {
+	v := Num{}
 	bts, _ := v.MarshalMsg(nil)
 	b.ReportAllocs()
 	b.SetBytes(int64(len(bts)))

--- a/_examples/hello_world/client/main.go
+++ b/_examples/hello_world/client/main.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+const (
+	Hello synapse.Method = 0
+)
+
 func main() {
 	// This sets up a TCP connection to
 	// localhost:7000 and attaches a client
@@ -28,7 +32,7 @@ func main() {
 	// provided for sending strings
 	// back and forth.
 	var res synapse.String
-	err = client.Call("hello", nil, &res)
+	err = client.Call(Hello, nil, &res)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/_examples/hello_world/server/main.go
+++ b/_examples/hello_world/server/main.go
@@ -5,25 +5,36 @@ import (
 	"log"
 )
 
-func main() {
-	// Like net/http, synapse uses
-	// routers to send requests to
-	// the appropriate handler(s).
-	// Here we'll use the one provided
-	// by the synapse package, although
-	// users can write their own.
-	router := synapse.NewRouter()
+const (
+	// Each route is simply
+	// an index into a table,
+	// much like a system call
+	// or a file descriptor.
+	// Generall, it's easiest
+	// to define your routes
+	// in a const-iota block.
+	Hello synapse.Method = iota
+)
 
-	// Here we're registering the "hello"
-	// route with a function that logs the
-	// remote address of the caller and then
-	// responds with "Hello, World!"
-	router.HandleFunc("hello", func(req synapse.Request, res synapse.ResponseWriter) {
-		log.Println("received request from client at", req.RemoteAddr())
-		res.Send(synapse.String("Hello, World!"))
-	})
+// helloHandler will implement
+// synapse.Handler
+type helloHandler struct{}
+
+func (h helloHandler) ServeCall(req synapse.Request, res synapse.ResponseWriter) {
+	log.Println("received request from client with addr", req.RemoteAddr())
+	res.Send(synapse.String("Hello, World!"))
+}
+
+func main() {
+	// RouteTable is the simplest
+	// form of request routing:
+	// it matches the method number
+	// to an index into the table.
+	rt := synapse.RouteTable{
+		Hello: helloHandler{},
+	}
 
 	// ListenAndServe blocks forever
 	// serving the provided handler.
-	log.Fatalln(synapse.ListenAndServe("tcp", "localhost:7000", router))
+	log.Fatalln(synapse.ListenAndServe("tcp", "localhost:7000", &rt))
 }

--- a/debug.go
+++ b/debug.go
@@ -2,11 +2,26 @@ package synapse
 
 import (
 	"bytes"
-	"github.com/tinylib/msgp/msgp"
+	"fmt"
 	"log"
 	"net"
-	"testing"
+	"time"
+
+	"github.com/tinylib/msgp/msgp"
 )
+
+var methodTab = map[Method]string{}
+
+func RegisterName(m Method, name string) {
+	methodTab[m] = name
+}
+
+func (m Method) String() string {
+	if str, ok := methodTab[m]; ok {
+		return str
+	}
+	return fmt.Sprintf("Method(%d)", m)
+}
 
 type logger interface {
 	Print(...interface{})
@@ -18,26 +33,10 @@ type debugh struct {
 	logger logger
 }
 
-// shim for *testing.T
-// to implement logger
-type tlog testing.T
-
-func (t *tlog) Print(v ...interface{})            { (*testing.T)(t).Log(v...) }
-func (t *tlog) Printf(s string, v ...interface{}) { (*testing.T)(t).Logf(s, v...) }
-
 // Debug wraps a handler and logs all of the incoming
 // and outgoing data using the provided logger.
 func Debug(h Handler, l *log.Logger) Handler {
 	return &debugh{inner: h, logger: l}
-}
-
-// DebugTest works identically to Debug, except
-// that it logs data to a *testing.T.
-//
-// (DebugTest only calls t.Log/f; it never calls t.Error/f
-// or t.Fatal/f.)
-func DebugTest(h Handler, t *testing.T) Handler {
-	return &debugh{inner: h, logger: (*tlog)(t)}
 }
 
 func (d *debugh) ServeCall(req Request, res ResponseWriter) {
@@ -52,44 +51,46 @@ func (d *debugh) ServeCall(req Request, res ResponseWriter) {
 	}
 
 	var buf bytes.Buffer
-	nm := req.Name()
+	nm := req.Method()
 	remote := req.RemoteAddr()
 
 	var raw msgp.Raw
 	err := req.Decode(&raw)
 	if err != nil {
-		d.logger.Printf("request from %s for %q is malformed: %s\n", remote, nm, err)
+		d.logger.Printf("request from %s for method %s is malformed: %s\n", remote, nm, err)
 		res.Error(StatusBadRequest, err.Error())
 		return
 	}
 	msgp.UnmarshalAsJSON(&buf, []byte(raw))
-	d.logger.Printf("request from %s:\n\tNAME: %q\n\tBODY: %s\n", remote, nm, buf.String())
+	d.logger.Printf("request from %s:\n\tMETHOD: %s\n\tBODY: %s\n", remote, nm, buf.Bytes())
 	buf.Reset()
 	r := &mockReq{
-		name:   nm,
+		mtd:    nm,
 		remote: remote,
 		raw:    raw,
 	}
 	w := &mockRes{}
+	start := time.Now()
 	d.inner.ServeCall(r, w)
+	ctime := time.Since(start)
 	if !w.wrote {
 		d.logger.Print("WARNING: handler for", nm, "did not write a valid response")
 		res.Error(StatusServerError, "empty response")
 		return
 	}
 	msgp.UnmarshalAsJSON(&buf, []byte(w.out))
-	d.logger.Printf("response to %s for %q:\n\tSTATUS: %s\n\tBODY: %s\n", remote, nm, w.status, buf.String())
+	d.logger.Printf("response to %s for method %s:\n\tSTATUS: %s\n\tBODY: %s\n\tDURATION: %s", remote, nm, w.status, buf.Bytes(), ctime)
 	res.Send(msgp.Raw(w.out))
 }
 
 type mockReq struct {
-	name   string
 	remote net.Addr
 	raw    msgp.Raw
+	mtd    Method
 }
 
 func (m *mockReq) IsNil() bool          { return msgp.IsNil([]byte(m.raw)) }
-func (m *mockReq) Name() string         { return m.name }
+func (m *mockReq) Method() Method       { return m.mtd }
 func (m *mockReq) RemoteAddr() net.Addr { return m.remote }
 func (m *mockReq) Decode(u msgp.Unmarshaler) error {
 	_, err := u.UnmarshalMsg([]byte(m.raw))
@@ -130,15 +131,17 @@ func (d *debugh) serveBase(req *request, res *response) {
 	_, err := msgp.UnmarshalAsJSON(&buf, req.in)
 	remote := req.addr.String()
 	if err != nil {
-		d.logger.Printf("request from %s for %q was malformed: %s", remote, req.name, err)
+		d.logger.Printf("request from %s for %s was malformed: %s", remote, Method(req.mtd), err)
 		res.Error(StatusBadRequest, err.Error())
 		return
 	}
-	d.logger.Printf("request from %s:\n\tNAME: %q\n\tBODY: %s\n", remote, req.name, buf.String())
+	d.logger.Printf("request from %s:\n\tMETHOD: %s\n\tREQUEST BODY: %s\n", remote, Method(req.mtd), buf.Bytes())
 	buf.Reset()
+	start := time.Now()
 	d.inner.ServeCall(req, res)
+	ctime := time.Since(start)
 	if !res.wrote || len(res.out) < leadSize {
-		d.logger.Print("WARNING: handler for", req.name, "did not write a valid response")
+		d.logger.Print("WARNING: handler for", Method(req.mtd), "did not write a valid response")
 		res.Error(StatusServerError, "empty response")
 		return
 	}
@@ -147,14 +150,14 @@ func (d *debugh) serveBase(req *request, res *response) {
 	var body []byte
 	stat, body, err = msgp.ReadIntBytes(out)
 	if err != nil {
-		d.logger.Printf("body of response to %s is malformed: %s", req.name, err)
+		d.logger.Printf("body of response to %s is malformed: %s", Method(req.mtd), err)
 		return
 	}
 	status := Status(stat)
 	_, err = msgp.UnmarshalAsJSON(&buf, body)
 	if err != nil {
-		d.logger.Printf("response for %s is malformed: %s", req.name, err)
+		d.logger.Printf("response for %s is malformed: %s", Method(req.mtd), err)
 		return
 	}
-	d.logger.Printf("response to %s for %q:\n\tSTATUS: %s\n\tBODY: %s\n", remote, req.name, status, buf.String())
+	d.logger.Printf("response to %s for %s:\n\tSTATUS: %s\n\tRESPONSE BODY: %s\n\tDURATION: %s\n", remote, Method(req.mtd), status, buf.Bytes(), ctime)
 }

--- a/mux.go
+++ b/mux.go
@@ -1,39 +1,27 @@
 package synapse
 
-// NewRouter returns a new, empty router.
-func NewRouter() *Router {
-	return &Router{hlrs: make(map[string]Handler)}
-}
+// RouteTable is the simplest and fastest
+// form of routing. Request methods map
+// directly to an index in the routing
+// table.
+//
+// Route tables should be used by defining
+// your methods in a const-iota block, and
+// then using those as indices in the routing
+// table.
+type RouteTable []Handler
 
-// Router is a request router. It
-// matches request names to handlers.
-// Request names must precisely match
-// the names of the handlers.
-type Router struct {
-	hlrs map[string]Handler
-}
-
-// Handle adds a named handler to the router.
-func (r *Router) Handle(name string, handler Handler) {
-	r.hlrs[name] = handler
-}
-
-// HandleFunc adds a new handler to the router.
-func (r *Router) HandleFunc(name string, f func(Request, ResponseWriter)) {
-	r.hlrs[name] = handlerFunc(f)
-}
-
-// shim for handlers as functions
-type handlerFunc func(req Request, res ResponseWriter)
-
-func (f handlerFunc) ServeCall(req Request, res ResponseWriter) { f(req, res) }
-
-// ServeCall implements the Handler interface.
-func (r *Router) ServeCall(req Request, res ResponseWriter) {
-	h, ok := r.hlrs[req.Name()]
-	if !ok {
-		res.Error(StatusNotFound, "no handler by that name")
+func (r *RouteTable) ServeCall(req Request, res ResponseWriter) {
+	m := req.Method()
+	if int(m) > len(*r) {
+		res.Error(StatusNotFound, "no such method")
+		return
+	}
+	h := (*r)[m]
+	if h == nil {
+		res.Error(StatusNotFound, "no such method")
 		return
 	}
 	h.ServeCall(req, res)
+	return
 }

--- a/request.go
+++ b/request.go
@@ -5,13 +5,15 @@ import (
 	"net"
 )
 
+type Method uint32
+
 // Request is the interface that
 // Handlers use to interact with
 // requests.
 type Request interface {
-	// Name returns the name of
-	// the requested method.
-	Name() string
+	// Method returns the
+	// request method.
+	Method() Method
 
 	// RemoteAddr returns the remote
 	// address that made the request.
@@ -30,11 +32,11 @@ type Request interface {
 // to the root handler of the server.
 type request struct {
 	addr net.Addr // remote address
-	name string   // method name
 	in   []byte   // body
+	mtd  uint32   // method
 }
 
-func (r *request) Name() string         { return r.name }
+func (r *request) Method() Method       { return Method(r.mtd) }
 func (r *request) RemoteAddr() net.Addr { return r.addr }
 
 func (r *request) Decode(m msgp.Unmarshaler) error {

--- a/server.go
+++ b/server.go
@@ -291,7 +291,7 @@ func (c *connHandler) handleReq(cw *connWrapper) {
 	var err error
 
 	// split request into 'name' and body
-	cw.req.name, cw.req.in, err = msgp.ReadStringBytes(cw.in)
+	cw.req.mtd, cw.req.in, err = msgp.ReadUint32Bytes(cw.in)
 	if err != nil {
 		cw.res.Error(StatusBadRequest, "malformed request method")
 	} else {


### PR DESCRIPTION
Routes go from being strings to numbers. Perhaps this is less flexible, but it fits with the minimalist ethos of the project. (This also cuts an allocation and a hashmap lookup on the server side.)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/synapse/25)

<!-- Reviewable:end -->
