### PR TITLE
Use runtime semaphores

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -117,7 +117,7 @@ func BenchmarkUnixNoop(b *testing.B) {
 		time.Sleep(1 * time.Millisecond)
 	}()
 	go Serve(l, NopHandler{})
-	cl, err := Dial("unix", "bench", 1*time.Millisecond)
+	cl, err := Dial("unix", "bench", 50*time.Millisecond)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func BenchmarkPipeNoop(b *testing.B) {
 
 	defer srv.Close()
 
-	cl, err := NewClient(cln, 1*time.Millisecond)
+	cl, err := NewClient(cln, 50*time.Millisecond)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/map.go
+++ b/map.go
@@ -2,6 +2,8 @@ package synapse
 
 import (
 	"sync"
+
+	"github.com/tinylib/synapse/sema"
 )
 
 const (
@@ -88,7 +90,7 @@ func (n *mNode) reap() {
 			}
 			*fwd, cur.next = cur.next, nil
 			cur.err = ErrTimeout
-			cur.done.Unlock()
+			sema.Wake(&cur.done)
 			cur = *fwd
 		} else {
 			cur.reap = true
@@ -105,7 +107,7 @@ func (n *mNode) flush(err error) {
 	for l := n.list; l != nil; {
 		next, l.next = l.next, nil
 		l.err = err
-		l.done.Unlock()
+		sema.Wake(&l.done)
 		l = next
 	}
 	n.list = nil

--- a/map_test.go
+++ b/map_test.go
@@ -38,7 +38,6 @@ func TestWaiterMap(t *testing.T) {
 		t.Errorf("expected map to have 0 elements; found %d", l)
 	}
 
-	vals[200].done.Lock()
 	mp.insert(&vals[200])
 
 	mp.flush(nil)
@@ -48,7 +47,6 @@ func TestWaiterMap(t *testing.T) {
 	}
 
 	for i := range vals {
-		vals[i].done.Lock()
 		mp.insert(&vals[i])
 	}
 
@@ -72,7 +70,6 @@ func TestWaiterMap(t *testing.T) {
 	}
 
 	for i := range vals {
-		vals[i].done.Lock()
 		vals[i].reap = false
 		mp.insert(&vals[i])
 	}

--- a/sema/sema14.go
+++ b/sema/sema14.go
@@ -1,0 +1,11 @@
+// +build go1.4
+
+package sema
+
+type Point uint32
+
+//go:noescape
+func Wait(p *Point)
+
+//go:noescape
+func Wake(p *Point)

--- a/sema/sema14_386.s
+++ b/sema/sema14_386.s
@@ -1,0 +1,9 @@
+// +build go1.4,!go1.5
+
+#define NOSPLIT 4
+
+TEXT ·Wait(SB),NOSPLIT,$0-0
+	JMP runtime·asyncsemacquire(SB)
+
+TEXT ·Wake(SB),NOSPLIT,$0-0
+	JMP runtime·semrelease(SB)

--- a/sema/sema14_amd64.s
+++ b/sema/sema14_amd64.s
@@ -1,0 +1,9 @@
+// +build go1.4,!go1.5
+
+#define NOSPLIT 4
+
+TEXT ·Wait(SB),NOSPLIT,$0-0
+	JMP runtime·asyncsemacquire(SB)
+
+TEXT ·Wake(SB),NOSPLIT,$0-0
+	JMP runtime·semrelease(SB)

--- a/sema/sema14_arm.s
+++ b/sema/sema14_arm.s
@@ -1,0 +1,9 @@
+// +build go1.4,!go1.5
+
+#define NOSPLIT 4
+
+TEXT ·Wait(SB),NOSPLIT,$0-0
+	B runtime·asyncsemacquire(SB)
+
+TEXT ·Wake(SB),NOSPLIT,$0-0
+	B runtime·semrelease(SB)

--- a/sema/sema15_386.s
+++ b/sema/sema15_386.s
@@ -1,0 +1,9 @@
+// +build go1.5
+
+#define NOSPLIT 4
+
+TEXT ·Wait(SB),NOSPLIT,$0-0
+	JMP sync·runtime_Semacquire(SB)
+
+TEXT ·Wake(SB),NOSPLIT,$0-0
+	JMP runtime·semrelease(SB)

--- a/sema/sema15_amd64.s
+++ b/sema/sema15_amd64.s
@@ -1,0 +1,9 @@
+// +build go1.5
+
+#define NOSPLIT 4
+
+TEXT ·Wait(SB),NOSPLIT,$0-0
+	JMP sync·runtime_Semacquire(SB)
+
+TEXT ·Wake(SB),NOSPLIT,$0-0
+	JMP runtime·semrelease(SB)

--- a/sema/sema15_arm.s
+++ b/sema/sema15_arm.s
@@ -1,0 +1,9 @@
+// +build go1.5
+
+#define NOSPLIT 4
+
+TEXT ·Wait(SB),NOSPLIT,$0-0
+	B sync·runtime_Semacquire(SB)
+
+TEXT ·Wake(SB),NOSPLIT,$0-0
+	B runtime·semrelease(SB)

--- a/stack.go
+++ b/stack.go
@@ -33,11 +33,9 @@ var (
 func init() {
 	// set up the pointers and lock
 	// the waiter semaphores
-	waiterSlab[0].done.Lock()
 	waiterSlab[0].static = true
 	for i := 0; i < (arenaSize - 1); i++ {
 		waiterSlab[i].next = &waiterSlab[i+1]
-		waiterSlab[i+1].done.Lock()
 		waiterSlab[i+1].static = true
 		wrapperSlab[i].next = &wrapperSlab[i+1]
 	}
@@ -94,7 +92,6 @@ func (s *waitStack) pop(c *Client) (ptr *waiter) {
 	spin.Unlock(&s.lock)
 	ptr = &waiter{}
 	ptr.parent = c
-	ptr.done.Lock()
 	return
 }
 

--- a/stack_race.go
+++ b/stack_race.go
@@ -18,7 +18,6 @@ type connStack struct{}
 func (ws waitStack) push(_ *waiter) {}
 func (ws waitStack) pop(c *Client) *waiter {
 	w := &waiter{parent: c}
-	w.done.Lock()
 	return w
 }
 


### PR DESCRIPTION
Replaces the mutex inside of `*waiter` with a runtime semaphore.

This has a couple advantages:
- `sync.Mutex` started doing busy waiting in go1.4. Since we were using it as a semaphore, this simply wasted cycles.
- The zero value of `*waiter` is now in the correct synchronization state.
- Profiles indicate that, at full throttle, we spend 25% of our time in syscalls, and another 20% of it in atomics (channel send/receive, waitgroups, etc.) This cuts down on a few atomics.

Of course, now we have to update `sema` to support the latest runtime every 6-month release cycle, but that seems like a reasonable price to pay for being able to break into the scheduler and tell it what we want it to do.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/synapse/26)

<!-- Reviewable:end -->
