### PR TITLE
Experimental - service discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: go
 
 go:
   - 1.4
+  - tip
+
+script: 
+  - go install ./...
+  - go test -v
+  - ./svc-test.bash

--- a/client.go
+++ b/client.go
@@ -442,16 +442,10 @@ func (c *Client) sendCommand(cmd command, msg []byte) error {
 
 	if ret == cmdInvalid || ret >= _maxcommand {
 		waiters.push(w)
-		return errInvalidCmd
-	}
-
-	act := cmdDirectory[ret]
-	if act == nil {
-		waiters.push(w)
 		return errUnknownCmd
 	}
 
-	act.Client(c, w.in[1:])
+	cmdDirectory[ret].done(c, w.in[1:])
 	waiters.push(w)
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -28,20 +28,20 @@ func TestNearest(t *testing.T) {
 	svc := Nearest("test-endpoint")
 	if svc == nil {
 		t.Error("expected Nearest(test-endpoint) to return something")
-	} else {
-		c, err := svc.Connect(5 * time.Millisecond)
-		if err != nil {
-			t.Errorf("couldn't connect to tcp service: %s", err)
-		}
-		c.Close()
 	}
 
 	all := Services("test-endpoint")
-	if len(all) != 2 {
-		for _, s := range all {
-			t.Logf("service: %#v", *s)
+	for _, s := range all {
+		t.Logf("found service: %v", s)
+		if s.Name() != "test-endpoint" {
+			t.Errorf("expected name %q -- got %q", "test-endpoint", s.Name())
 		}
-		t.Errorf("expected Services(test-endpoint) to return 2 elements; found %d", len(all))
+		if s.HostID() != hostid {
+			t.Errorf("expected host id %d; got %d", hostid, s.HostID())
+		}
+	}
+	if len(all) < 2 {
+		t.Errorf("expected at least 2 services; found %d", len(all))
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -16,6 +16,7 @@ func isCode(err error, c Status) bool {
 }
 
 func TestClientServiceName(t *testing.T) {
+	setTestLog(t)
 	if tcpClient.Service() != "test-endpoint" {
 		t.Errorf("expected service endpoint to be %q, but got %q", "test-endpoint", tcpClient.Service())
 	}
@@ -25,6 +26,7 @@ func TestClientServiceName(t *testing.T) {
 }
 
 func TestNearest(t *testing.T) {
+	setTestLog(t)
 	svc := Nearest("test-endpoint")
 	if svc == nil {
 		t.Error("expected Nearest(test-endpoint) to return something")
@@ -51,6 +53,7 @@ func TestNearest(t *testing.T) {
 // open up a client and server; make
 // some concurrent requests
 func TestClient(t *testing.T) {
+	setTestLog(t)
 
 	const concurrent = 5
 	wg := new(sync.WaitGroup)
@@ -83,6 +86,7 @@ func TestClient(t *testing.T) {
 // the output of the debug handler
 // is only visible if '-v' is set
 func TestDebugClient(t *testing.T) {
+	setTestLog(t)
 	instr := String("here's a message body!")
 	var outstr String
 	err := tcpClient.Call(DebugEcho, &instr, &outstr)
@@ -97,6 +101,7 @@ func TestDebugClient(t *testing.T) {
 // test that 'nil' is a safe
 // argument to requests and responses
 func TestNop(t *testing.T) {
+	setTestLog(t)
 	err := tcpClient.Call(Nop, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/client_test.go
+++ b/client_test.go
@@ -29,6 +29,9 @@ func TestNearest(t *testing.T) {
 	if svc == nil {
 		t.Error("expected Nearest(test-endpoint) to return something")
 	}
+	if nwk, _ := svc.Addr(); nwk != "unix" {
+		t.Error("expected nearest endpoint to be a unix socket")
+	}
 
 	all := Services("test-endpoint")
 	for _, s := range all {

--- a/command.go
+++ b/command.go
@@ -77,6 +77,8 @@ const (
 	// command
 	cmdPing
 
+	// sync service addresses
+	// between client and server
 	cmdListLinks
 
 	// a command >= _maxcommand

--- a/command.go
+++ b/command.go
@@ -88,12 +88,13 @@ const (
 
 // client-side ping finalizer
 func recvping(cl *Client, res []byte) {
+	r := cl.conn.RemoteAddr()
 	var s Service
 	_, err := s.UnmarshalMsg(res)
 	if err != nil {
+		errorf("server at addr %s sent a malformed ping response", r)
 		return
 	}
-	r := cl.conn.RemoteAddr()
 	s.net = r.Network()
 	s.addr = r.String()
 	cache(&s)
@@ -113,6 +114,7 @@ func recvlinks(cl *Client, res []byte) {
 	sl := serviceTable{}
 	_, err := sl.UnmarshalMsg(res)
 	if err != nil {
+		errorf("server at addr %s sent malformed links: %s", cl.conn.RemoteAddr(), err)
 		return
 	}
 	svcCache.Lock()

--- a/server.go
+++ b/server.go
@@ -134,10 +134,10 @@ func putFrame(bts []byte, seq uint64, ft fType, sz int) {
 type route uint16
 
 const (
-	routeUnknown   route = iota
-	routeGlobal          // globally routable
-	routeLinkLocal       // link-local
-	routeOSLocal         // same machine (unix socket / loopback)
+	routeUnknown   route = iota // no idea
+	routeGlobal                 // globally routable
+	routeLinkLocal              // link-local
+	routeOSLocal                // same machine (unix socket / loopback)
 )
 
 func getRoute(c net.Conn) route {
@@ -360,9 +360,6 @@ func (c *connHandler) handleReq(cw *connWrapper) {
 }
 
 func handleCmd(c *connHandler, seq uint64, cmd command, body []byte) {
-	if cmd == cmdInvalid || cmd >= _maxcommand {
-		return
-	}
 	resbyte := byte(cmd)
 	var res []byte
 	var err error

--- a/server.go
+++ b/server.go
@@ -94,7 +94,7 @@ func ServeConn(c net.Conn, service string, h Handler) {
 		h:       h,
 		remote:  c.RemoteAddr(),
 		writing: make(chan *connWrapper, 32),
-		route:   getRoute(c),
+		route:   getRoute(c.RemoteAddr()),
 	}
 	go ch.writeLoop()
 	ch.connLoop()     // returns on connection close
@@ -140,14 +140,13 @@ const (
 	routeOSLocal                // same machine (unix socket / loopback)
 )
 
-func getRoute(c net.Conn) route {
-	raddr := c.RemoteAddr()
+func getRoute(raddr net.Addr) route {
 	nwk := raddr.Network()
 	switch nwk {
 	case "unix":
 		return routeOSLocal
 	case "tcp", "tcp4", "tcp6":
-		a, err := net.ResolveIPAddr(nwk, raddr.String())
+		a, err := net.ResolveTCPAddr(nwk, raddr.String())
 		if err != nil {
 			return routeUnknown
 		}

--- a/service.go
+++ b/service.go
@@ -150,9 +150,12 @@ func isRoutable(s *Service) bool {
 	switch s.net {
 	case "tcp", "tcp6", "tcp4":
 		a, err := net.ResolveTCPAddr(s.net, s.addr)
-
+		if err != nil {
+			errorf("couldn't resolve tcp addr %s: %s", s.addr, err)
+			return false
+		}
 		// TODO: link-local addresses
-		return err == nil && a.IP.IsGlobalUnicast()
+		return a.IP.IsGlobalUnicast()
 	default:
 		return false
 	}

--- a/service.go
+++ b/service.go
@@ -68,9 +68,21 @@ func (s *Service) Addr() (net, addr string) {
 
 type serviceList []*Service
 
-func (s serviceList) Len() int           { return len(s) }
-func (s serviceList) Less(i, j int) bool { return s[i].dist < s[j].dist }
-func (s serviceList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s serviceList) Len() int { return len(s) }
+func (s serviceList) Less(i, j int) bool {
+
+	// for os-local addresses, prefer unix sockets
+	// over loopback tcp
+	if s[i].dist == 0 && s[i].dist == s[j].dist {
+		if s[i].net == "unix" && s[j].net != "unix" {
+			return true
+		}
+	}
+
+	return s[i].dist < s[j].dist
+}
+
+func (s serviceList) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func addSvc(list []*Service, s *Service) []*Service {
 	if len(list) == 0 {

--- a/service.go
+++ b/service.go
@@ -1,10 +1,12 @@
 package synapse
 
 import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
 	"net"
 	"sort"
 	"sync"
-	"time"
 )
 
 //go:generate msgp -unexported -io=false
@@ -40,16 +42,23 @@ func Services(name string) []*Service {
 // Service represents a unique address
 // associated with a service.
 type Service struct {
-	name, net, addr string
-	distance        int32
+	host            uint64 // host id
+	name, net, addr string // address
+	dist            int32  // distance
 }
+
+func (s *Service) HostID() uint64 { return s.host }
+
+func (s *Service) Name() string { return s.name }
 
 func (s *Service) eqaddr(g *Service) bool {
 	return s.net == g.net && s.addr == g.addr
 }
 
+// String returns {Name}#{HostID}@{net}:{addr}
+// e.g. echo#9081234973@tcp:localhost:7000
 func (s *Service) String() string {
-	return s.name + "@" + s.net + ":" + s.addr
+	return fmt.Sprintf("%s#%d@%s:%s", s.name, s.host, s.net, s.addr)
 }
 
 func (s *Service) Addr() (net, addr string) {
@@ -57,19 +66,10 @@ func (s *Service) Addr() (net, addr string) {
 	return
 }
 
-func (s *Service) Connect(timeout time.Duration) (*Client, error) {
-	conn, err := net.Dial(s.net, s.addr)
-	if err != nil {
-		uncache(s)
-		return nil, err
-	}
-	return NewClient(conn, timeout)
-}
-
 type serviceList []*Service
 
 func (s serviceList) Len() int           { return len(s) }
-func (s serviceList) Less(i, j int) bool { return s[i].distance < s[j].distance }
+func (s serviceList) Less(i, j int) bool { return s[i].dist < s[j].dist }
 func (s serviceList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 func addSvc(list []*Service, s *Service) []*Service {
@@ -78,8 +78,8 @@ func addSvc(list []*Service, s *Service) []*Service {
 	}
 	for _, sv := range list {
 		if sv.eqaddr(s) {
-			if s.distance < sv.distance {
-				sv.distance = s.distance
+			if s.dist < sv.dist {
+				sv.dist = s.dist
 			}
 			return list
 		}
@@ -106,26 +106,49 @@ func removeSvc(list []*Service, s *Service) []*Service {
 
 type serviceTable map[string]serviceList
 
+// svcCache stores all of the
+// known services to this hostid.
+//
 var svcCache struct {
 	sync.Mutex
 	tab serviceTable
 }
 
+// host id
+var hostid uint64
+
+func HostID() uint64 { return hostid }
+
 func init() {
 	svcCache.tab = make(serviceTable)
+
+	var buf [8]byte
+	rand.Read(buf[:])
+	hostid = binary.LittleEndian.Uint64(buf[:])
+}
+
+func isRoutable(s *Service) bool {
+	// unix sockets, etc. can
+	// be connected to on the
+	// same machine
+	if s.dist == 0 {
+		return true
+	}
+
+	switch s.net {
+	case "tcp", "tcp6", "tcp4":
+		a, err := net.ResolveTCPAddr(s.net, s.addr)
+
+		// TODO: link-local addresses
+		return err == nil && a.IP.IsGlobalUnicast()
+	default:
+		return false
+	}
 }
 
 func cache(s *Service) {
 	svcCache.Lock()
 	svcCache.tab[s.name] = addSvc(svcCache.tab[s.name], s)
-	svcCache.Unlock()
-}
-
-func cachelist(l serviceList) {
-	svcCache.Lock()
-	for _, sv := range l {
-		svcCache.tab[sv.name] = addSvc(svcCache.tab[sv.name], sv)
-	}
 	svcCache.Unlock()
 }
 

--- a/service.go
+++ b/service.go
@@ -1,0 +1,143 @@
+package synapse
+
+import (
+	"net"
+	"sort"
+	"sync"
+	"time"
+)
+
+//go:generate msgp -unexported -io=false
+
+// Nearest finds the "nearest" service
+// with the given name.
+func Nearest(service string) (s *Service) {
+	svcCache.Lock()
+	l := svcCache.tab[service]
+	if len(l) > 0 {
+		s = l[0]
+	}
+	svcCache.Unlock()
+	return
+}
+
+// Services lists all of the known
+// services endpoints for a given
+// service name.
+func Services(name string) []*Service {
+	svcCache.Lock()
+	l := svcCache.tab[name]
+	if len(l) == 0 {
+		svcCache.Unlock()
+		return nil
+	}
+	dup := make([]*Service, len(l))
+	copy(dup, l)
+	svcCache.Unlock()
+	return dup
+}
+
+// Service represents a unique address
+// associated with a service.
+type Service struct {
+	name, net, addr string
+	distance        int32
+}
+
+func (s *Service) eqaddr(g *Service) bool {
+	return s.net == g.net && s.addr == g.addr
+}
+
+func (s *Service) String() string {
+	return s.name + "@" + s.net + ":" + s.addr
+}
+
+func (s *Service) Addr() (net, addr string) {
+	net, addr = s.net, s.addr
+	return
+}
+
+func (s *Service) Connect(timeout time.Duration) (*Client, error) {
+	conn, err := net.Dial(s.net, s.addr)
+	if err != nil {
+		uncache(s)
+		return nil, err
+	}
+	return NewClient(conn, timeout)
+}
+
+type serviceList []*Service
+
+func (s serviceList) Len() int           { return len(s) }
+func (s serviceList) Less(i, j int) bool { return s[i].distance < s[j].distance }
+func (s serviceList) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+func addSvc(list []*Service, s *Service) []*Service {
+	if len(list) == 0 {
+		return []*Service{s}
+	}
+	for _, sv := range list {
+		if sv.eqaddr(s) {
+			if s.distance < sv.distance {
+				sv.distance = s.distance
+			}
+			return list
+		}
+	}
+	out := append(list, s)
+	sort.Sort(serviceList(out))
+	return out
+}
+
+func removeSvc(list []*Service, s *Service) []*Service {
+	ll := len(list)
+	if ll == 0 {
+		return nil
+	}
+	for i, sv := range list {
+		if sv.eqaddr(s) {
+			list[i], list[ll-1], list = list[ll-1], nil, list[:ll-1]
+			sort.Sort(serviceList(list))
+			return list
+		}
+	}
+	return list
+}
+
+type serviceTable map[string]serviceList
+
+var svcCache struct {
+	sync.Mutex
+	tab serviceTable
+}
+
+func init() {
+	svcCache.tab = make(serviceTable)
+}
+
+func cache(s *Service) {
+	svcCache.Lock()
+	svcCache.tab[s.name] = addSvc(svcCache.tab[s.name], s)
+	svcCache.Unlock()
+}
+
+func cachelist(l serviceList) {
+	svcCache.Lock()
+	for _, sv := range l {
+		svcCache.tab[sv.name] = addSvc(svcCache.tab[sv.name], sv)
+	}
+	svcCache.Unlock()
+}
+
+func uncache(s *Service) {
+	svcCache.Lock()
+	svcCache.tab[s.name] = removeSvc(svcCache.tab[s.name], s)
+	svcCache.Unlock()
+}
+
+func svclistbytes() []byte {
+	svcCache.Lock()
+	data, _ := svcCache.tab.MarshalMsg(nil)
+	svcCache.Unlock()
+	return data
+}

--- a/service_gen.go
+++ b/service_gen.go
@@ -1,0 +1,236 @@
+package synapse
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"github.com/tinylib/msgp/msgp"
+)
+
+// MarshalMsg implements msgp.Marshaler
+func (z *Service) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "name"
+	o = append(o, 0x84, 0xa4, 0x6e, 0x61, 0x6d, 0x65)
+	o = msgp.AppendString(o, z.name)
+	// string "net"
+	o = append(o, 0xa3, 0x6e, 0x65, 0x74)
+	o = msgp.AppendString(o, z.net)
+	// string "addr"
+	o = append(o, 0xa4, 0x61, 0x64, 0x64, 0x72)
+	o = msgp.AppendString(o, z.addr)
+	// string "distance"
+	o = append(o, 0xa8, 0x64, 0x69, 0x73, 0x74, 0x61, 0x6e, 0x63, 0x65)
+	o = msgp.AppendInt32(o, z.distance)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *Service) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var isz uint32
+	isz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for isz > 0 {
+		isz--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "name":
+			z.name, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "net":
+			z.net, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "addr":
+			z.addr, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				return
+			}
+		case "distance":
+			z.distance, bts, err = msgp.ReadInt32Bytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z *Service) Msgsize() (s int) {
+	s = 1 + 5 + msgp.StringPrefixSize + len(z.name) + 4 + msgp.StringPrefixSize + len(z.net) + 5 + msgp.StringPrefixSize + len(z.addr) + 9 + msgp.Int32Size
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z serviceList) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendArrayHeader(o, uint32(len(z)))
+	for xvk := range z {
+		if z[xvk] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o, err = z[xvk].MarshalMsg(o)
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *serviceList) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var xsz uint32
+	xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if cap((*z)) >= int(xsz) {
+		(*z) = (*z)[:xsz]
+	} else {
+		(*z) = make(serviceList, xsz)
+	}
+	for bzg := range *z {
+		if msgp.IsNil(bts) {
+			bts, err = msgp.ReadNilBytes(bts)
+			if err != nil {
+				return
+			}
+			(*z)[bzg] = nil
+		} else {
+			if (*z)[bzg] == nil {
+				(*z)[bzg] = new(Service)
+			}
+			bts, err = (*z)[bzg].UnmarshalMsg(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+func (z serviceList) Msgsize() (s int) {
+	s = msgp.ArrayHeaderSize
+	for bai := range z {
+		if z[bai] == nil {
+			s += msgp.NilSize
+		} else {
+			s += z[bai].Msgsize()
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z serviceTable) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendMapHeader(o, uint32(len(z)))
+	for cmr, ajw := range z {
+		o = msgp.AppendString(o, cmr)
+		o = msgp.AppendArrayHeader(o, uint32(len(ajw)))
+		for wht := range ajw {
+			if ajw[wht] == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o, err = ajw[wht].MarshalMsg(o)
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *serviceTable) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var msz uint32
+	msz, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	if (*z) == nil && msz > 0 {
+		(*z) = make(serviceTable, msz)
+	} else if len((*z)) > 0 {
+		for key, _ := range *z {
+			delete((*z), key)
+		}
+	}
+	for msz > 0 {
+		var hct string
+		var cua serviceList
+		msz--
+		hct, bts, err = msgp.ReadStringBytes(bts)
+		if err != nil {
+			return
+		}
+		var xsz uint32
+		xsz, bts, err = msgp.ReadArrayHeaderBytes(bts)
+		if err != nil {
+			return
+		}
+		if cap(cua) >= int(xsz) {
+			cua = cua[:xsz]
+		} else {
+			cua = make(serviceList, xsz)
+		}
+		for xhx := range cua {
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				cua[xhx] = nil
+			} else {
+				if cua[xhx] == nil {
+					cua[xhx] = new(Service)
+				}
+				bts, err = cua[xhx].UnmarshalMsg(bts)
+				if err != nil {
+					return
+				}
+			}
+		}
+		(*z)[hct] = cua
+	}
+	o = bts
+	return
+}
+
+func (z serviceTable) Msgsize() (s int) {
+	s = msgp.MapHeaderSize
+	if z != nil {
+		for lqf, daf := range z {
+			_ = daf
+			s += msgp.StringPrefixSize + len(lqf) + msgp.ArrayHeaderSize
+			for pks := range daf {
+				if daf[pks] == nil {
+					s += msgp.NilSize
+				} else {
+					s += daf[pks].Msgsize()
+				}
+			}
+		}
+	}
+	return
+}

--- a/service_gen.go
+++ b/service_gen.go
@@ -11,9 +11,12 @@ import (
 // MarshalMsg implements msgp.Marshaler
 func (z *Service) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
+	// map header, size 5
+	// string "host"
+	o = append(o, 0x85, 0xa4, 0x68, 0x6f, 0x73, 0x74)
+	o = msgp.AppendUint64(o, z.host)
 	// string "name"
-	o = append(o, 0x84, 0xa4, 0x6e, 0x61, 0x6d, 0x65)
+	o = append(o, 0xa4, 0x6e, 0x61, 0x6d, 0x65)
 	o = msgp.AppendString(o, z.name)
 	// string "net"
 	o = append(o, 0xa3, 0x6e, 0x65, 0x74)
@@ -21,9 +24,9 @@ func (z *Service) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "addr"
 	o = append(o, 0xa4, 0x61, 0x64, 0x64, 0x72)
 	o = msgp.AppendString(o, z.addr)
-	// string "distance"
-	o = append(o, 0xa8, 0x64, 0x69, 0x73, 0x74, 0x61, 0x6e, 0x63, 0x65)
-	o = msgp.AppendInt32(o, z.distance)
+	// string "dist"
+	o = append(o, 0xa4, 0x64, 0x69, 0x73, 0x74)
+	o = msgp.AppendInt32(o, z.dist)
 	return
 }
 
@@ -43,6 +46,11 @@ func (z *Service) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			return
 		}
 		switch msgp.UnsafeString(field) {
+		case "host":
+			z.host, bts, err = msgp.ReadUint64Bytes(bts)
+			if err != nil {
+				return
+			}
 		case "name":
 			z.name, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
@@ -58,8 +66,8 @@ func (z *Service) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			if err != nil {
 				return
 			}
-		case "distance":
-			z.distance, bts, err = msgp.ReadInt32Bytes(bts)
+		case "dist":
+			z.dist, bts, err = msgp.ReadInt32Bytes(bts)
 			if err != nil {
 				return
 			}
@@ -75,7 +83,7 @@ func (z *Service) UnmarshalMsg(bts []byte) (o []byte, err error) {
 }
 
 func (z *Service) Msgsize() (s int) {
-	s = 1 + 5 + msgp.StringPrefixSize + len(z.name) + 4 + msgp.StringPrefixSize + len(z.net) + 5 + msgp.StringPrefixSize + len(z.addr) + 9 + msgp.Int32Size
+	s = 1 + 5 + msgp.Uint64Size + 5 + msgp.StringPrefixSize + len(z.name) + 4 + msgp.StringPrefixSize + len(z.net) + 5 + msgp.StringPrefixSize + len(z.addr) + 5 + msgp.Int32Size
 	return
 }
 

--- a/service_gen_test.go
+++ b/service_gen_test.go
@@ -1,0 +1,185 @@
+package synapse
+
+// NOTE: THIS FILE WAS PRODUCED BY THE
+// MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
+// DO NOT EDIT
+
+import (
+	"testing"
+
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMarshalUnmarshalService(t *testing.T) {
+	v := Service{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgService(b *testing.B) {
+	v := Service{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgService(b *testing.B) {
+	v := Service{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalService(b *testing.B) {
+	v := Service{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalserviceList(t *testing.T) {
+	v := serviceList{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgserviceList(b *testing.B) {
+	v := serviceList{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgserviceList(b *testing.B) {
+	v := serviceList{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalserviceList(b *testing.B) {
+	v := serviceList{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalserviceTable(t *testing.T) {
+	v := serviceTable{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgserviceTable(b *testing.B) {
+	v := serviceTable{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgserviceTable(b *testing.B) {
+	v := serviceTable{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalserviceTable(b *testing.B) {
+	v := serviceTable{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -97,14 +97,14 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	go Serve(l, rt)
+	go Serve(l, "test-endpoint", rt)
 
 	ul, err := net.Listen("unix", "synapse")
 	if err != nil {
 		panic(err)
 	}
 
-	go Serve(ul, rt)
+	go Serve(ul, "test-endpoint", rt)
 
 	tcpClient, err = Dial("tcp", ":7070", 5*time.Millisecond)
 	if err != nil {

--- a/svc-test.bash
+++ b/svc-test.bash
@@ -1,8 +1,9 @@
 #! /bin/bash
-
+set -e
 ssts &
 SSTS_PID=$!
 sleep 0.1
+set +e
 sstc
 RET=$?
 eval kill -s SIGINT $SSTS_PID || echo "Couldn't kill server."

--- a/svc-test.bash
+++ b/svc-test.bash
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+ssts &
+SSTS_PID=$!
+sleep 0.1
+sstc
+RET=$?
+eval kill -s SIGINT $SSTS_PID || echo "Couldn't kill server."
+exit $RET

--- a/svc_test/sstc/main.go
+++ b/svc_test/sstc/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -36,6 +37,10 @@ func dumpservices(srv string) {
 	}
 }
 
+func init() {
+	synapse.ErrorLogger = log.New(os.Stderr, "syn-client-log: ", log.LstdFlags)
+}
+
 func main() {
 	cl, err := synapse.Dial("tcp", *port, 25*time.Millisecond)
 	if err != nil {
@@ -43,7 +48,7 @@ func main() {
 	}
 	fmt.Println("client: connected to service", cl.Service())
 
-	err = cl.Call("echo", synapse.String("hello!"), nil)
+	err = cl.Call(0, synapse.String("hello!"), nil)
 	if err != nil {
 		perror("client: call error:", err)
 	}
@@ -70,6 +75,10 @@ func main() {
 	if err != nil {
 		perror("client: couldn't dial socket:", err)
 	}
+	// give the second client time
+	// to complete another round of
+	// list synchronization.
+	time.Sleep(50 * time.Millisecond)
 	err = cl2.Close()
 	if err != nil {
 		perror("client: close error:", err)

--- a/svc_test/sstc/main.go
+++ b/svc_test/sstc/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	port = flag.String("port", ":7000", "tcp port to dial")
+	port = flag.String("port", ":7005", "tcp port to dial")
 )
 
 func fatalln(str string) {
@@ -24,7 +24,7 @@ func perror(str string, err error) {
 }
 
 func dumpservices(srv string) {
-	fmt.Print("Known addresses for service", srv)
+	fmt.Print("Known addresses for service ", srv)
 	sv := synapse.Services(srv)
 	if len(sv) == 0 {
 		fmt.Print(": None.\n")
@@ -39,13 +39,13 @@ func dumpservices(srv string) {
 func main() {
 	cl, err := synapse.Dial("tcp", *port, 25*time.Millisecond)
 	if err != nil {
-		perror("dial failure:", err)
+		perror("client: dial failure:", err)
 	}
-	fmt.Println("Connected to service", cl.Service())
+	fmt.Println("client: connected to service", cl.Service())
 
 	err = cl.Call("echo", synapse.String("hello!"), nil)
 	if err != nil {
-		perror("call error:", err)
+		perror("client: call error:", err)
 	}
 
 	// wait for service lists to synchronize
@@ -55,28 +55,29 @@ func main() {
 
 	ss := synapse.Nearest(cl.Service())
 	if ss == nil {
-		fatalln("Nearest() returned nil")
+		fatalln("client: Nearest() returned nil")
 	}
 
 	nwk, sock := ss.Addr()
 	if nwk != "unix" {
-		fatalln("Nearest(service).Addr() didn't return a unix socket")
+		fatalln("client: Nearest(service).Addr() didn't return a unix socket")
 	}
 
-	fmt.Println("Found socket", sock)
+	fmt.Println("client: found socket", sock)
 	var cl2 *synapse.Client
 
 	cl2, err = synapse.Dial(nwk, sock, 25*time.Millisecond)
 	if err != nil {
-		perror("couldn't dial socket:", err)
+		perror("client: couldn't dial socket:", err)
 	}
 	err = cl2.Close()
 	if err != nil {
-		perror("close error:", err)
+		perror("client: close error:", err)
 	}
 
 	err = cl.Close()
 	if err != nil {
-		perror("close error:", err)
+		perror("client: close error:", err)
 	}
+	fmt.Println("client: exiting successfully")
 }

--- a/svc_test/ssts/main.go
+++ b/svc_test/ssts/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	sock = flag.String("sock", "ssvc_sock", "unix socket to listen on")
-	port = flag.String("port", ":7000", "tcp port to dial")
+	port = flag.String("port", ":7005", "tcp port to dial")
 )
 
 func fatalln(str string) {
@@ -32,15 +32,15 @@ type echoHandler struct{}
 func (e echoHandler) ServeCall(req synapse.Request, res synapse.ResponseWriter) {
 	var r msgp.Raw
 	if err := req.Decode(&r); err != nil {
-		perror("error on Request.Decode():", err)
+		perror("server: error on Request.Decode():", err)
 	}
 	if err := res.Send(r); err != nil {
-		perror("error on ResponseWriter.Send():", err)
+		perror("server: error on ResponseWriter.Send():", err)
 	}
 
 	sv := synapse.Services("service-test")
 	for _, s := range sv {
-		fmt.Println("Server: known service:", s)
+		fmt.Println("serrver: known service:", s)
 	}
 }
 
@@ -48,12 +48,12 @@ func main() {
 	go func() {
 		err := synapse.ListenAndServe("tcp", *port, "service-test", echoHandler{})
 		if err != nil {
-			perror("listen tcp error:", err)
+			perror("server: listen tcp error:", err)
 		}
 	}()
 	ul, err := net.Listen("unix", *sock)
 	if err != nil {
-		perror("listen unix error:", err)
+		perror("server: listen unix error:", err)
 	}
 
 	// cleanup unix socket
@@ -64,10 +64,12 @@ func main() {
 		signal.Notify(in, os.Interrupt)
 		<-in
 		ul.Close()
+		fmt.Println("server: exiting successfully")
+		os.Exit(0)
 	}()
 
 	err = synapse.Serve(ul, "service-test", echoHandler{})
 	if err != nil && !strings.Contains(err.Error(), "closed") {
-		perror("serve unix error:", err)
+		perror("server: serve unix error:", err)
 	}
 }

--- a/svc_test/ssts/main.go
+++ b/svc_test/ssts/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"os/signal"
@@ -42,6 +43,10 @@ func (e echoHandler) ServeCall(req synapse.Request, res synapse.ResponseWriter) 
 	for _, s := range sv {
 		fmt.Println("serrver: known service:", s)
 	}
+}
+
+func init() {
+	synapse.ErrorLogger = log.New(os.Stderr, "syn-server-log: ", log.LstdFlags)
 }
 
 func main() {

--- a/svc_test/ssts/main.go
+++ b/svc_test/ssts/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+
+	"github.com/tinylib/msgp/msgp"
+	"github.com/tinylib/synapse"
+)
+
+var (
+	sock = flag.String("sock", "ssvc_sock", "unix socket to listen on")
+	port = flag.String("port", ":7000", "tcp port to dial")
+)
+
+func fatalln(str string) {
+	fmt.Println(str)
+	os.Exit(1)
+}
+
+func perror(str string, err error) {
+	fmt.Println(str, err)
+	os.Exit(1)
+}
+
+type echoHandler struct{}
+
+func (e echoHandler) ServeCall(req synapse.Request, res synapse.ResponseWriter) {
+	var r msgp.Raw
+	if err := req.Decode(&r); err != nil {
+		perror("error on Request.Decode():", err)
+	}
+	if err := res.Send(r); err != nil {
+		perror("error on ResponseWriter.Send():", err)
+	}
+
+	sv := synapse.Services("service-test")
+	for _, s := range sv {
+		fmt.Println("Server: known service:", s)
+	}
+}
+
+func main() {
+	go func() {
+		err := synapse.ListenAndServe("tcp", *port, "service-test", echoHandler{})
+		if err != nil {
+			perror("listen tcp error:", err)
+		}
+	}()
+	ul, err := net.Listen("unix", *sock)
+	if err != nil {
+		perror("listen unix error:", err)
+	}
+
+	// cleanup unix socket
+	// on kill so we don't
+	// leave it lying around
+	go func() {
+		in := make(chan os.Signal, 1)
+		signal.Notify(in, os.Interrupt)
+		<-in
+		ul.Close()
+	}()
+
+	err = synapse.Serve(ul, "service-test", echoHandler{})
+	if err != nil && !strings.Contains(err.Error(), "closed") {
+		perror("serve unix error:", err)
+	}
+}


### PR DESCRIPTION
This doesn't work yet. Right now it doesn't draw a distinction between locally- vs. globally-routable addresses. Unix sockets and loopback addresses should only be cached at distance=0.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tinylib/synapse/27)

<!-- Reviewable:end -->
